### PR TITLE
First Blood API addition

### DIFF
--- a/models/minecraft.js
+++ b/models/minecraft.js
@@ -63,6 +63,7 @@ var MinecraftUser = new Schema({
     deaths                  : Number,
     wins                    : Number,
     losses                  : Number,
+    firstBloods             : Number,
     matches                 : [ObjectId],
     
     wool_destroys           : Number,

--- a/routes/minecraft/deaths.js
+++ b/routes/minecraft/deaths.js
@@ -99,6 +99,11 @@ module.exports = function(app) {
                     MinecraftUser.update({_id: death.killer}, {$inc: {kills: 1}}, function(err3) {
                         if(err3) console.log(err3);
                     });
+                    if(req.body.firstBlood) {
+                        MinecraftUser.update({_id: death.killer}, {$inc: {firstBloods: 1}}, function(err4) {
+                            if(err4) console.log(err4);
+                        });
+                    }
                 }
 
                 res.json({});


### PR DESCRIPTION
- Adds First Blood to the MinecraftUser schema
- Adds 1 to firstBloods for killer on new death

Obviously, this is supplementary to the PR that adds First Bloods:
https://github.com/WarzoneMC/Warzone/pull/418

I was debating whether to add First Bloods to Matches, however, I decided against it due to feedback I received. So, for now, it is just in the MinecraftUser schema.