### PR TITLE
Parse byUUID query parameter as a boolean

### DIFF
--- a/routes/minecraft/players.js
+++ b/routes/minecraft/players.js
@@ -15,7 +15,7 @@ module.exports = function(app) {
     app.get('/mc/player/:name', function(req, res, next) {
         let simple = req.query.simple;
         var query;
-        if (req.query.byUUID) {
+        if (req.query.byUUID === ('true'||'false') && Boolean(req.query.byUUID)) {
             query = {uuid: req.params.name}
         } else {
             query = {nameLower: req.params.name.toLowerCase()};


### PR DESCRIPTION
Validates that ?byUUID is true or false (stringified) and parses the value as a boolean

closes #35 